### PR TITLE
Upgraded consul-template to 13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM alpine:3.2
 MAINTAINER TLDR
 
-ENV CONSUL_TEMPLATE_VERSION=0.10.0
+ENV CONSUL_TEMPLATE_VERSION=0.13.0
 
 # Updata wget to get support for SSL
 RUN apk --update add haproxy wget


### PR DESCRIPTION
Switched to use consul-template version 13.0 which has been compiled with the new 1.6 version of go and fixes the issue with multiple processes being left over after haproxy restarts.
